### PR TITLE
Pylint update to 3.0.0

### DIFF
--- a/check-lint
+++ b/check-lint
@@ -2,9 +2,8 @@
 
 TOOL_CMD=pylint
 PATH=$(basename $0)/utils:$PATH
-TOOL_PATH=$(which pylint-3 2>/dev/null || which pylint)
 CONFIG_PATH="$(dirname $0)/default_configs/pylintrc"
 FILES=$(git ls-files '*.py')
 
-echo "** Running $TOOL_CMD ($TOOL_PATH using config from $CONFIG_PATH)..."
-$TOOL_PATH --rcfile=$CONFIG_PATH $FILES
+echo "** Running $TOOL_CMD (using config from $CONFIG_PATH)..."
+python3 -m pylint --rcfile=$CONFIG_PATH $FILES

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 isort==5.10.1
 black==22.3.0
-pylint==2.17.2
+pylint==3.0.0


### PR DESCRIPTION
This is a duplication of PR https://github.com/avocado-framework/avocado/pull/5959 which will align the avocado-static-checks with avocado code base to make transition to avocado much easier.