### PR TITLE
Address pylint exception warning

### DIFF
--- a/default_configs/pylintrc
+++ b/default_configs/pylintrc
@@ -495,5 +495,5 @@ valid-metaclass-classmethod-first-arg=cls
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception


### PR DESCRIPTION
Pylint gives the following warning:

   pylint: Command line or configuration file:1: UserWarning:
   'BaseException' is not a proper value for the 'overgeneral-exceptions'
   option. Use fully qualified name (maybe 'builtins.BaseException' ?)
   instead. This will cease to be checked at runtime in 3.1.0.

   pylint: Command line or configuration file:1: UserWarning:
   'Exception' is not a proper value for the 'overgeneral-exceptions'
   option. Use fully qualified name (maybe 'builtins.Exception' ?)
   instead. This will cease to be checked at runtime in 3.1.0.

This addresses it in the recomendded way.