### PR TITLE
check-lint: add support for subdirectories from config file

### DIFF
--- a/check-lint
+++ b/check-lint
@@ -67,7 +67,7 @@ if [ -f "$CONFIG_FILE" ]; then
             fi
 
             # Get all Python files in the specified directory
-            FILES=$(git ls-files "$DIRECTORY_PATH/*.py")
+            FILES=$(git ls-files "$DIRECTORY_PATH/" | grep -e '.py$')
 
             if [ -n "$FILES" ]; then
                 echo "** Running $TOOL_CMD on directory '$DIRECTORY_PATH' with config from '$CONFIG_PATH'..."


### PR DESCRIPTION
Currently, when using the "avocado-static-checks.conf" configuration file to specify the pylint configuration for a specific directory, only the files on the immediate directory are used.

This is a problem with complex projects, such as Avocado itself, that have many subdirectories.

With this change, all the Python files in subdirectories starting from the directory given in the "avocado-static-checks.conf" file will be used.  The side effect of this change is that, if one intends to use different configurations for different subdirectories, then the base directory must not be given, but all subdirectories starting from where the configuration diverges must be entered in the "avocado-static-checks.conf" file.

---

Reference: https://github.com/avocado-framework/avocado/issues/5989