### PR TITLE
lint check to use bash interpreter

### DIFF
--- a/check-lint
+++ b/check-lint
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 TOOL_NAME=pylint
 TOOL_CMD="python3 -m $TOOL_NAME"


### PR DESCRIPTION
The check-lint script uses some bash features, therefore it needs to be specified with shebang. Because on some platforms this script may not work properly. For example, Ubuntu and `dash` interpreter which is used by some of our CIs.