### PR TITLE
stages: [commit-msg] removal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,4 +46,3 @@ repos:
   hooks:
     - id: commitlint
       additional_dependencies: ['@commitlint/config-conventional']
-      stages: [commit-msg]


### PR DESCRIPTION
This will remove commit-msg from stages configuration which will enable commitinit for every run of pre-commit check. This will fix the issues in CI when this check is not run, bacause it use to be run only in commit process.